### PR TITLE
Fix misc errors, give climbable nodes the potential to be hideable

### DIFF
--- a/src/maps/town.tmx
+++ b/src/maps/town.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="80" height="14" tilewidth="24" tileheight="24" nextobjectid="23">
+<map version="1.0" orientation="orthogonal" renderorder="right-down" width="80" height="14" tilewidth="24" tileheight="24" nextobjectid="24">
  <properties>
   <property name="blue" value="124"/>
   <property name="floor" value="9"/>
@@ -86,8 +86,11 @@
   </object>
   <object id="4" name="tavern" type="door" x="360" y="216" width="24" height="48">
    <properties>
+    <property name="hideable" value="true"/>
+    <property name="invisible" value="true"/>
     <property name="level" value="tavern"/>
     <property name="to" value="main"/>
+    <property name="triggerClose" value="acornKingVisible"/>
    </properties>
   </object>
   <object id="5" name="blacksmith" type="building" x="1080" y="144" width="144" height="120">
@@ -97,14 +100,20 @@
   </object>
   <object id="6" name="blacksmith" type="door" x="1176" y="216" width="24" height="48">
    <properties>
+    <property name="hideable" value="true"/>
+    <property name="invisible" value="true"/>
     <property name="level" value="blacksmith"/>
     <property name="to" value="main"/>
+    <property name="triggerClose" value="acornKingVisible"/>
    </properties>
   </object>
   <object id="7" name="house" type="door" x="768" y="216" width="24" height="48">
    <properties>
+    <property name="hideable" value="true"/>
+    <property name="invisible" value="true"/>
     <property name="level" value="house"/>
     <property name="to" value="main"/>
+    <property name="triggerClose" value="acornKingVisible"/>
    </properties>
   </object>
   <object id="8" type="climbable" x="560" y="165" width="11" height="100"/>
@@ -131,7 +140,7 @@
    </properties>
   </object>
   <object id="18" name="hilda" type="npc" x="480" y="216" width="48" height="48"/>
-  <object id="19" type="enemy" x="240" y="192" width="71" height="70">
+  <object id="19" type="enemy" x="1530" y="192" width="71" height="70">
    <properties>
     <property name="enemytype" value="acornBoss"/>
    </properties>

--- a/src/maps/village-forest-stonerspeak-2.tmx
+++ b/src/maps/village-forest-stonerspeak-2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="24" tileheight="24" nextobjectid="9">
+<map version="1.0" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="24" tileheight="24" nextobjectid="11">
  <properties>
   <property name="offset" value="26"/>
   <property name="soundtrack" value="forest"/>

--- a/src/maps/village-forest-stonerspeak-return.tmx
+++ b/src/maps/village-forest-stonerspeak-return.tmx
@@ -87,7 +87,7 @@
    eJzt3clq3EAQxnHf5skNcfIGvhjs5JoFfDHEyTUL5JnSQ2hQRLfUS/VS1f8fFJhBI8ma/tSLxvjmBoBFt5fRZwCgNXIO2EfOAfvIOWAfOQfsI+eAfeQcsI+cA/aRc8A+cg7Y9cbl+46MA+b4bNOHY0UPl39lFX03UGfme8QtfTcQNHNuc5FxYIztHDlU7119iOTz0b3+FHhPDDkHZMTyGquzfXmf3c9fXD27+ujq0yW83VnOU48NrKB0vC6Zn9R9peYcgIxROaefxopyx8/XeuvqXWVOyDnQT017r7kHjMg5sKpWGTnL+4ic31/+L2AVrfvC2P5ZhwP6KX2WlbP/K78u79fmmZ+jtRbrStZI57zV/nP2Rc7X0roP08zPXS3mHGsh53HS12CmnLMOF+e/G/yyq2+uviu9VjU5t34/aDU/T31d8hhH21n+DEN8jh8ideZF4fWSyLn1dmI156t8fltW/o6wJ98+rLYTy/PzVXM+mrbx/wrjPsvz85V8ddfkdcK59vZ8Yq+PPt+anGvpR7TMz0v6ZuvrcNtsH5kh7zl6n+++PeW0VW3j/VlyLjnW1jYe2/fJv1z9dvVnUz9c/UzIdoi2vPfo40PtIjfnGvpzjfPzVDX3jNA4ODT+rNVqv6nH1LKu3mp8X5tzLaTnzUc57/39hZJjSbb90L0CckLX8+jZWmob7J3z/fm0+L6ulnGHBvtcoz+p+V7PPMSO1Srv1vRahyPX85DKaMl6Umkuz44lkXfp+flMtK3Dod6InJe+N3f7mrxrav+5812+J4NSNTnPeX/utn77VveSkXy+c9Gfo9TMOS95z6j2f7RmJfXch5xjlJT5es3/65R4rtBarzWr0b8ncDVL7gAAAAAAAAAAAABA2l9a1Dbx
   </data>
  </layer>
- <objectgroup color="#000000" name="nodes" visible="0">
+ <objectgroup color="#000000" name="nodes">
   <object id="1" type="movingplatform" x="3061" y="849" width="48" height="24">
    <properties>
     <property name="line" value="platform_4"/>
@@ -422,46 +422,6 @@
     <property name="level" value="forest"/>
     <property name="quest" value="asdsad"/>
     <property name="to" value="main"/>
-   </properties>
-  </object>
-  <object id="82" type="door" x="1968" y="1116" width="1680" height="48">
-   <properties>
-    <property name="instant" value="true"/>
-    <property name="level" value="village-forest-acornpeak"/>
-    <property name="sound" value="false"/>
-    <property name="to" value="clouds2"/>
-   </properties>
-  </object>
-  <object id="83" type="door" x="3888" y="1116" width="1680" height="48">
-   <properties>
-    <property name="instant" value="true"/>
-    <property name="level" value="village-forest-acornpeak"/>
-    <property name="sound" value="false"/>
-    <property name="to" value="clouds3"/>
-   </properties>
-  </object>
-  <object id="84" type="door" x="288" y="1116" width="1680" height="48">
-   <properties>
-    <property name="instant" value="true"/>
-    <property name="level" value="village-forest-acornpeak"/>
-    <property name="sound" value="false"/>
-    <property name="to" value="clouds1"/>
-   </properties>
-  </object>
-  <object id="85" type="door" x="0" y="1116" width="96" height="48">
-   <properties>
-    <property name="instant" value="true"/>
-    <property name="level" value="village-forest-acornpeak"/>
-    <property name="sound" value="false"/>
-    <property name="to" value="clouds"/>
-   </properties>
-  </object>
-  <object id="86" type="door" x="5568" y="1116" width="432" height="48">
-   <properties>
-    <property name="instant" value="true"/>
-    <property name="level" value="village-forest-2"/>
-    <property name="sound" value="false"/>
-    <property name="to" value="clouds"/>
    </properties>
   </object>
  </objectgroup>

--- a/src/maps/village-forest-stonerspeak.tmx
+++ b/src/maps/village-forest-stonerspeak.tmx
@@ -417,46 +417,6 @@
    </properties>
   </object>
   <object id="68" name="boulder" type="material" x="5856" y="240" width="24" height="24"/>
-  <object id="84" type="door" x="1968" y="1080" width="1680" height="48">
-   <properties>
-    <property name="instant" value="true"/>
-    <property name="level" value="village-forest-acornpeak"/>
-    <property name="sound" value="false"/>
-    <property name="to" value="clouds2"/>
-   </properties>
-  </object>
-  <object id="82" type="door" x="288" y="1080" width="1680" height="48">
-   <properties>
-    <property name="instant" value="true"/>
-    <property name="level" value="village-forest-acornpeak"/>
-    <property name="sound" value="false"/>
-    <property name="to" value="clouds1"/>
-   </properties>
-  </object>
-  <object id="83" type="door" x="0" y="1080" width="96" height="48">
-   <properties>
-    <property name="instant" value="true"/>
-    <property name="level" value="village-forest-acornpeak"/>
-    <property name="sound" value="false"/>
-    <property name="to" value="clouds"/>
-   </properties>
-  </object>
-  <object id="86" type="door" x="3888" y="1080" width="1680" height="48">
-   <properties>
-    <property name="instant" value="true"/>
-    <property name="level" value="village-forest-acornpeak"/>
-    <property name="sound" value="false"/>
-    <property name="to" value="clouds3"/>
-   </properties>
-  </object>
-  <object id="85" type="door" x="5568" y="1080" width="432" height="48">
-   <properties>
-    <property name="instant" value="true"/>
-    <property name="level" value="village-forest-2"/>
-    <property name="sound" value="false"/>
-    <property name="to" value="clouds"/>
-   </properties>
-  </object>
  </objectgroup>
  <objectgroup color="#a7a7a7" name="movement">
   <object id="69" name="platform_1" x="1560" y="696">

--- a/src/nodes/material.lua
+++ b/src/nodes/material.lua
@@ -8,6 +8,7 @@ local game = require 'game'
 local collision  = require 'hawk/collision'
 local Item = require 'items/item'
 local utils = require 'utils'
+local file = require 'items/materials'
 
 local Material = {}
 Material.__index = Material
@@ -21,8 +22,9 @@ function Material.new(node, collider)
   setmetatable(material, Material)
   material.name = node.name
   material.type = 'material'
-  material.width = node.width or 24
-  material.height = node.height or 24
+  local file = utils.require( 'nodes/materials/' .. material.name)
+  material.width = file.width or 24
+  material.height = file.height or 24
   material.image = love.graphics.newImage('images/materials/'..node.name..'.png')
   material.image_q = love.graphics.newQuad( 0, 0, material.width, material.height, material.image:getWidth(),material.image:getHeight() )
   material.foreground = node.properties.foreground
@@ -38,7 +40,7 @@ function Material.new(node, collider)
   material.height = node.height
   material.bb_offset_x = (24 - node.width) / 2 -- positions bb for materials smaller than 24px
 
-  material.touchedPlayer = nil
+  material.touchedPlayer = nilma
   material.exists = true
   material.dropping = false
 

--- a/src/nodes/materials/blade.lua
+++ b/src/nodes/materials/blade.lua
@@ -1,0 +1,3 @@
+return{
+  name = "blade",
+}

--- a/src/nodes/materials/bluemushroom.lua
+++ b/src/nodes/materials/bluemushroom.lua
@@ -1,0 +1,3 @@
+return{
+  name = "bluemushroom",
+}

--- a/src/nodes/materials/boulder.lua
+++ b/src/nodes/materials/boulder.lua
@@ -1,0 +1,3 @@
+return{
+  name = "boulder",
+}

--- a/src/nodes/materials/ember.lua
+++ b/src/nodes/materials/ember.lua
@@ -1,0 +1,3 @@
+return{
+  name = "ember",
+}

--- a/src/nodes/materials/fire.lua
+++ b/src/nodes/materials/fire.lua
@@ -1,0 +1,3 @@
+return{
+  name = "fire",
+}

--- a/src/nodes/materials/lost.lua
+++ b/src/nodes/materials/lost.lua
@@ -1,0 +1,3 @@
+return{
+  name = "lost",
+}

--- a/src/nodes/materials/potato.lua
+++ b/src/nodes/materials/potato.lua
@@ -1,0 +1,3 @@
+return{
+  name = "potato",
+}

--- a/src/nodes/materials/stone.lua
+++ b/src/nodes/materials/stone.lua
@@ -1,0 +1,3 @@
+return{
+  name = "stone",
+}

--- a/src/nodes/npc.lua
+++ b/src/nodes/npc.lua
@@ -285,6 +285,9 @@ function NPC.new(node, collider)
   npc.walk_speed = npc.props.walk_speed or 18
   npc.wasWalking = false
   npc.velocity = {x=0, y=0}
+  --npcs running away
+  npc.flee = npc.props.flee or false
+  npc.hidden = false
   
   npc.run_speed = npc.props.run_speed or 100
 

--- a/src/npcs/hilda.lua
+++ b/src/npcs/hilda.lua
@@ -57,6 +57,7 @@ return {
       npc.x = 900
       npc.minx = 1250
       npc.maxx = 1250 + (48 * 2)
+      npc.flee = false
 
       -- Hilda waits until she notices the fire
       Timer.add(5, function()
@@ -106,11 +107,11 @@ return {
     local show = npc.db:get('acornKingVisible', false)
     local acornDead = npc.db:get("bosstriggers.acorn", true)
     if show == true then
-      npc.state = 'hidden'
+      npc.state = 'walking'
       npc.collider:setGhost(npc.bb)
+      npc.run_offsets = {{x=5, y=0}, {x=-1000, y=0}, {x=-990, y=0}}
+      npc.flee = true
     end
-
-
     if previous and previous.name ~= 'town' then
       return
     end
@@ -762,6 +763,9 @@ return {
     -- she is running to the blacksmith
     if npc.state == 'yelling' then
       npc:run(dt, player)
+    end
+    if npc.flee then
+    	npc:run(dt, player)
     end
 
     if npc.state == 'sad' then

--- a/src/npcs/hilda.lua
+++ b/src/npcs/hilda.lua
@@ -51,7 +51,7 @@ return {
 
   enter = function(npc, previous)
     -- If the blacksmith is dead and Hilda hasn't cried yet
-    if npc.db:get('blacksmith-dead', false) and npc.db:get('hilda-cried', false) == false then
+    if npc.db:get('blacksmith-dead', false) and npc.db:get('hilda-cried', false) == false or npc.db:get('blacksmith_building_burned', false ) and npc.db:get('hilda-cried', false) == false then
       -- Hilda will come from just off-screen when the player leaves the blacksmith level
       npc.position.x = 900
       npc.x = 900

--- a/src/npcs/oldman.lua
+++ b/src/npcs/oldman.lua
@@ -4,6 +4,8 @@ local Dialog = require 'dialog'
 return {
   width = 32,
   height = 32,  
+  run_speed = 36,
+  run_offsets = {{x=5, y=0}, {x=-1000, y=0}, {x=-990, y=0}},
   greeting = 'Bah! Go away.',
   animations = {
     default = {
@@ -15,7 +17,13 @@ return {
     local show = npc.db:get('acornKingVisible', false)
     local acornDead = npc.db:get("bosstriggers.acorn", true)
     local bldgburned = npc.db:get('house_building_burned', false )
-    if show == true or bldgburned == true then
+    if show == true and not npc.hidden then 
+      npc.collider:setGhost(npc.bb)
+      npc.run_offsets = {{x=5, y=0}, {x=-1000, y=0}, {x=-990, y=0}}
+      npc.flee = true
+      npc.hidden = true
+    elseif bldgburned == true then
+      npc.flee = false
       npc.state = 'hidden'
       npc.collider:setGhost(npc.bb)
     end
@@ -73,4 +81,9 @@ return {
       "Piss off, would ya?",
     },
   },
+  update = function(dt, npc, player)
+    if npc.flee== true then
+      npc:run(dt, player)
+    end
+  end,
 }

--- a/src/npcs/oldman.lua
+++ b/src/npcs/oldman.lua
@@ -11,10 +11,11 @@ return {
     },
   },
 
-  enter = function(npc, previous)
+ enter = function(npc, previous)
     local show = npc.db:get('acornKingVisible', false)
     local acornDead = npc.db:get("bosstriggers.acorn", true)
-    if show == true then
+    local bldgburned = npc.db:get('house_building_burned', false )
+    if show == true or bldgburned == true then
       npc.state = 'hidden'
       npc.collider:setGhost(npc.bb)
     end

--- a/src/npcs/quests/wifequest.lua
+++ b/src/npcs/quests/wifequest.lua
@@ -12,7 +12,7 @@ local quests = {
         "Just on the other side of the mountains on the way to {{orange}}Valley of Laziness{{white}}, there's a hidden door leading to the treetops. you may have noticed {{teal}}flowers{{white}} growing beside the road. from the {{olive}}forest{{white}} beyond the {{green_light}}blacksmith{{white}} but ever since {{grey}}Hawkthorne{{white}} started ruling the {{olive}}forests{{white}} haven't been safe.",
         "Recently, an invasive species of {{blue_light}}blue mushrooms{{white}} have begun growing there, threatening local plants!",
       },
-    successPrompt = "Could you go remove those mushrooms on the treetops? I will pay you handsomely!",
+    successPrompt = "Could you go remove ALL of those {{blue_light}} mushrooms{{white}} on the treetops? I will pay you handsomely!",
     completeQuestFail = "The {{blue_light}}blue mushrooms{{white}} are in the treetops, on the way to {{orange}}Valley of Laziness{{white}}! Please remove them for me!",
     completeQuestSucceed = "Thank you for removing those mushrooms! You can probably sell those in shops in {{orange}}Valley of Laziness{{white}}.",
     reward = {money = 300},

--- a/src/npcs/townknight.lua
+++ b/src/npcs/townknight.lua
@@ -29,11 +29,13 @@ return {
     local show = npc.db:get('acornKingVisible', false)
     local acornDead = npc.db:get("bosstriggers.acorn", true)
     if show == true then
-        npc.emotion = Emotion.new(npc, "exclaim")
-        npc.angry = true
-        npc.stare = false
-        npc.state = 'attack'
-        npc.attackingEnemy = true
+      npc.state = 'hidden'
+      npc.collider:setGhost(npc.bb)
+        --[[npc.emotion = Emotion.new(npc, "exclaim")
+            npc.angry = true
+            npc.stare = false
+            npc.state = 'attack'
+            npc.attackingEnemy = true]]
     end
   end,
 

--- a/src/npcs/townknight.lua
+++ b/src/npcs/townknight.lua
@@ -7,6 +7,8 @@ return {
   width = 70,
   --bb_width = 40,
   height = 55,
+  run_offsets = {{x=5, y=0}, {x=-1200, y=0}, {x=-1190, y=0}},
+  run_speed = 50,
   greeting = 'My name is {{red_light}}Sir Merek{{white}}, I became a knight to protect this {{olive}}village{{white}} from the dangers of the forest.',
   special_enemy = {'acornBoss'},
   animations = {
@@ -28,15 +30,26 @@ return {
   enter = function(npc, previous)
     local show = npc.db:get('acornKingVisible', false)
     local acornDead = npc.db:get("bosstriggers.acorn", true)
-    if show == true then
+    local bldgburned = npc.db:get('blacksmith_building_burned', false )
+    if show == true and not npc.hidden then 
+        --[[npc.emotion = Emotion.new(npc, "exclaim")
+      npc.angry = true
+      npc.stare = false
+      npc.state = 'attack'
+      npc.attackingEnemy = true]]
+      npc.state = 'walking'
+      npc.walking = true
+      npc.stare = false
+      npc.collider:setGhost(npc.bb)
+      npc.run_offsets = {{x=5, y=0}, {x=-1200, y=0}, {x=-1190, y=0}}
+      npc.flee = true
+      npc.hidden = true
+    elseif bldgburned == true then
+      npc.flee = false
       npc.state = 'hidden'
       npc.collider:setGhost(npc.bb)
-        --[[npc.emotion = Emotion.new(npc, "exclaim")
-            npc.angry = true
-            npc.stare = false
-            npc.state = 'attack'
-            npc.attackingEnemy = true]]
     end
+    
   end,
 
   talk_items = {
@@ -71,5 +84,10 @@ return {
     },
 
   },
+  update = function(dt, npc, player)
+    if npc.flee then
+      npc:run(dt, player)
+    end
+  end,
 
 }

--- a/src/npcs/townsperson.lua
+++ b/src/npcs/townsperson.lua
@@ -5,6 +5,8 @@ local app = require 'app'
 return {
   width = 32,
   height = 48,  
+  run_speed = 50,
+  run_offsets = {{x=5, y=0}, {x=-1000, y=0}, {x=-990, y=0}},
   animations = {
     default = {
       'loop',{'1,1','11,1'},.5,
@@ -15,13 +17,21 @@ return {
   },
 
   walking = true,
-  walk_speed = 36,
+  --walk_speed = 36,
 
  enter = function(npc, previous)
     local show = npc.db:get('acornKingVisible', false)
     local acornDead = npc.db:get("bosstriggers.acorn", true)
     local bldgburned = npc.db:get('house_building_burned', false )
-    if show == true or bldgburned == true then
+    if show == true and not npc.hidden then
+      print('run away')
+      npc.state = 'walking'
+      npc.collider:setGhost(npc.bb)
+      npc.run_offsets = {{x=5, y=0}, {x=-1000, y=0}, {x=-990, y=0}}
+      npc.flee = true
+      npc.hidden = true
+    elseif bldgburned == true then
+      npc.flee = false
       npc.state = 'hidden'
       npc.collider:setGhost(npc.bb)
     end
@@ -60,4 +70,9 @@ return {
       "You can find him at the last house on the street.",
     },
   },
+  update = function(dt, npc, player)
+    if npc.flee then
+      npc:run(dt, player)
+    end
+  end,
 }

--- a/src/npcs/townsperson.lua
+++ b/src/npcs/townsperson.lua
@@ -17,10 +17,11 @@ return {
   walking = true,
   walk_speed = 36,
 
-  enter = function(npc, previous)
+ enter = function(npc, previous)
     local show = npc.db:get('acornKingVisible', false)
     local acornDead = npc.db:get("bosstriggers.acorn", true)
-    if show == true then
+    local bldgburned = npc.db:get('house_building_burned', false )
+    if show == true or bldgburned == true then
       npc.state = 'hidden'
       npc.collider:setGhost(npc.bb)
     end


### PR DESCRIPTION
This pull does several things. Fixed a previous material error that I had created, makes npcs flee when the acorn boss is in the level,, hides the npcs if the buildings are burnt and also give climbable nodes the potential to be hideable.  The only issue with that is they don't display a sprite when they're unhidden.  I'm not sure how to do that.

If we want the village-forest to be in the V1.0 release we need to wrap this up for testing ASAP.
